### PR TITLE
Fix panic for images without version.

### DIFF
--- a/datatypes/deployment.go
+++ b/datatypes/deployment.go
@@ -62,9 +62,18 @@ func DeploymentFromNotification(notice *Notification) *Deployment {
 		Name:        svc.Name,
 		StartTime:   evt.Time,
 		EndTime:     evt.Time,
-		Version:     strings.Split(evt.Service.Image, ":")[1],
+		Version:     version(evt.Service.Image),
 		Image:       evt.Service.Image,
 		ClusterName: notice.ClusterName,
 		Hostnames:   []string{evt.Service.Hostname},
 	}
+}
+
+// Extract version from format 'name:version'
+func version(image string) string {
+	split := strings.Split(image, ":")
+	if len(split) <= 1 {
+		return ""
+	}
+	return split[1]
 }

--- a/datatypes/deployment_test.go
+++ b/datatypes/deployment_test.go
@@ -57,6 +57,12 @@ func Test_DeploymentFromNotification(t *testing.T) {
 		So(deploy.ID, ShouldNotBeEmpty)
 		So(deploy.ClusterName, ShouldEqual, notice.ClusterName)
 		So(deploy.Version, ShouldEqual, "0.1")
+
+		Convey("Process images without version", func() {
+			notice.Event.Service.Image = "awesome-svc"
+			deploy = DeploymentFromNotification(notice)
+			So(deploy.Version, ShouldEqual, "")
+		})
 	})
 }
 


### PR DESCRIPTION
For instances:
```
  "ChangeEvent": {
    "Service": {
      "ID": "1b3c44ba25e9",
      "Name": "nginx",
      "Image": "nginx",
```